### PR TITLE
Fixed missing LI tag in Navbar.js

### DIFF
--- a/frontend/src/components/layout/Navbar.js
+++ b/frontend/src/components/layout/Navbar.js
@@ -11,21 +11,16 @@ function Navbar({onLogout}) {
 
             <div className="collapse navbar-collapse" id="navbarColor01">
                 <ul className="navbar-nav mx-auto">
-                
-
-
                         <li className="nav-item">
                             <Link to="/buyer" className="nav-link">
                                 Buyer
                             </Link>
                         </li>
-                     
-                       
                         <li className="nav-item">
                             <Link to="/about" className="nav-link">
                                 About 
                             </Link>
-
+                        </li>
                         <li className="nav-item">
                             <Link to="/seller" className="nav-link">
                                 Seller


### PR DESCRIPTION
A closing LI tag was missing in Navbar.js and causing error in loading the application